### PR TITLE
Get action workflows

### DIFF
--- a/GitHubConsumer/Controllers/GitHubController.cs
+++ b/GitHubConsumer/Controllers/GitHubController.cs
@@ -1,4 +1,5 @@
 ﻿using GitHubConsumer.Models;
+using GitHubConsumer.Utilities;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
 using System.Net.Http.Headers;
@@ -21,44 +22,10 @@ namespace GitHubConsumer.Controllers
         }
 
         [HttpGet]
-        public IEnumerable<GitHubRepo> GitHub()
+        public IEnumerable<GitHubRepo> GetRepos()
         {
-            IEnumerable<GitHubRepo> data = new List<GitHubRepo>();
-
             string owner = "meddlin";
-            string URL = "https://api.github.com/users/" + owner + "/repos";
-            // string urlParameters = "?api_key=123";
-
-            /*
-             * Set up the HttpClient
-             */
-            HttpClient client = new HttpClient();
-            client.BaseAddress = new Uri(URL);
-            client.DefaultRequestHeaders.Accept.Add(
-                new MediaTypeWithQualityHeaderValue("application/vnd.github.v3+json")
-            );
-            client.DefaultRequestHeaders.UserAgent.Add(new System.Net.Http.Headers.ProductInfoHeaderValue("GitHubConsumerApp", "1.0"));
-            client.DefaultRequestHeaders.Add("X-GitHub-Api-Version", "2022-11-28");
-            client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Token", Configuration.GetValue<string>("GitHubToken"));
-
-            /*
-             * Call the API, and process the response.
-             */
-            HttpResponseMessage response = client.GetAsync(URL).Result;  // Blocking call! Program will wait here until a response is received or a timeout occurs.
-            if (response.IsSuccessStatusCode)
-            {
-                // ...but we also get the string for debugging
-                var simpleData = response.Content.ReadAsStringAsync().Result;
-                Console.WriteLine(simpleData);
-
-                // Parse the response -- we want the JSON
-                data = response.Content.ReadFromJsonAsync<IEnumerable<GitHubRepo>>().Result;
-            }
-            else
-            {
-                // Print the unsuccessful response code.
-                Console.WriteLine("{0} ({1})", (int)response.StatusCode, response.ReasonPhrase);
-            }
+            List<GitHubRepo> data = GitHubRestClient.GetRepos(owner, Configuration.GetValue<string>("GitHubToken")).ToList();
 
             return data;
         }

--- a/GitHubConsumer/Controllers/GitHubController.cs
+++ b/GitHubConsumer/Controllers/GitHubController.cs
@@ -41,7 +41,6 @@ namespace GitHubConsumer.Controllers
             client.DefaultRequestHeaders.Add("X-GitHub-Api-Version", "2022-11-28");
             client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Token", Configuration.GetValue<string>("GitHubToken"));
 
-
             /*
              * Call the API, and process the response.
              */
@@ -54,8 +53,6 @@ namespace GitHubConsumer.Controllers
 
                 // Parse the response -- we want the JSON
                 data = response.Content.ReadFromJsonAsync<IEnumerable<GitHubRepo>>().Result;
-                
-                
             }
             else
             {
@@ -64,6 +61,47 @@ namespace GitHubConsumer.Controllers
             }
 
             return data;
+        }
+
+        [HttpGet]
+        public void RepoWorkflows()
+        {
+            string API_BASE = "https://api.github.com";
+            string owner = "meddlin";
+            string repo = "amortize-client";
+            string URL = API_BASE + "/repos/" + owner + "/" + repo + "/actions/workflows";
+            /*
+             * Set up the HttpClient
+             */
+            HttpClient client = new HttpClient();
+            client.BaseAddress = new Uri(URL);
+            client.DefaultRequestHeaders.Accept.Add(
+                new MediaTypeWithQualityHeaderValue("application/vnd.github.v3+json")
+            );
+            client.DefaultRequestHeaders.UserAgent.Add(new System.Net.Http.Headers.ProductInfoHeaderValue("GitHubConsumerApp", "1.0"));
+            client.DefaultRequestHeaders.Add("X-GitHub-Api-Version", "2022-11-28");
+            client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Token", Configuration.GetValue<string>("GitHubToken"));
+
+
+            IEnumerable<GitHubActionsWorkflow> data = new List<GitHubActionsWorkflow>();
+            /*
+             * Call the API, and process the response.
+             */
+            HttpResponseMessage response = client.GetAsync(URL).Result;  // Blocking call! Program will wait here until a response is received or a timeout occurs.
+            if (response.IsSuccessStatusCode)
+            {
+                // ...but we also get the string for debugging
+                var simpleData = response.Content.ReadAsStringAsync().Result;
+                Console.WriteLine(simpleData);
+
+                // Parse the response -- we want the JSON
+                data = response.Content.ReadFromJsonAsync<IEnumerable<GitHubActionsWorkflow>>().Result;
+            }
+            else
+            {
+                // Print the unsuccessful response code.
+                Console.WriteLine("{0} ({1})", (int)response.StatusCode, response.ReasonPhrase);
+            }
         }
     }
 }

--- a/GitHubConsumer/Controllers/GitHubController.cs
+++ b/GitHubConsumer/Controllers/GitHubController.cs
@@ -31,44 +31,12 @@ namespace GitHubConsumer.Controllers
         }
 
         [HttpGet]
-        public void RepoWorkflows()
+        public GitHubActionsWorkflowResponse RepoWorkflows()
         {
-            string API_BASE = "https://api.github.com";
             string owner = "meddlin";
             string repo = "amortize-client";
-            string URL = API_BASE + "/repos/" + owner + "/" + repo + "/actions/workflows";
-            /*
-             * Set up the HttpClient
-             */
-            HttpClient client = new HttpClient();
-            client.BaseAddress = new Uri(URL);
-            client.DefaultRequestHeaders.Accept.Add(
-                new MediaTypeWithQualityHeaderValue("application/vnd.github.v3+json")
-            );
-            client.DefaultRequestHeaders.UserAgent.Add(new System.Net.Http.Headers.ProductInfoHeaderValue("GitHubConsumerApp", "1.0"));
-            client.DefaultRequestHeaders.Add("X-GitHub-Api-Version", "2022-11-28");
-            client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Token", Configuration.GetValue<string>("GitHubToken"));
-
-
-            IEnumerable<GitHubActionsWorkflow> data = new List<GitHubActionsWorkflow>();
-            /*
-             * Call the API, and process the response.
-             */
-            HttpResponseMessage response = client.GetAsync(URL).Result;  // Blocking call! Program will wait here until a response is received or a timeout occurs.
-            if (response.IsSuccessStatusCode)
-            {
-                // ...but we also get the string for debugging
-                var simpleData = response.Content.ReadAsStringAsync().Result;
-                Console.WriteLine(simpleData);
-
-                // Parse the response -- we want the JSON
-                data = response.Content.ReadFromJsonAsync<IEnumerable<GitHubActionsWorkflow>>().Result;
-            }
-            else
-            {
-                // Print the unsuccessful response code.
-                Console.WriteLine("{0} ({1})", (int)response.StatusCode, response.ReasonPhrase);
-            }
+            GitHubActionsWorkflowResponse data = GitHubRestClient.GetRepoWorkflows(owner, repo, Configuration.GetValue<string>("GitHubToken"));
+            return data;
         }
     }
 }

--- a/GitHubConsumer/Models/GitHubActionsWorkflow.cs
+++ b/GitHubConsumer/Models/GitHubActionsWorkflow.cs
@@ -1,0 +1,16 @@
+﻿namespace GitHubConsumer.Models
+{
+    public class GitHubActionsWorkflow
+    {
+        public int Id { get; set; }
+        public string? Node_Id { get; set; }
+        public string? Name { get; set; }
+        public string? Path { get; set; }
+        public string? State { get; set; }
+        public DateTime Created_At { get; set; }
+        public DateTime Updated_At { get; set; }
+        public string? Url { get; set; }
+        public string? Html_Url { get; set; }
+        public string? Badge_Url { get; set; }
+    }
+}

--- a/GitHubConsumer/Models/GitHubActionsWorkflow.cs
+++ b/GitHubConsumer/Models/GitHubActionsWorkflow.cs
@@ -1,5 +1,11 @@
 ﻿namespace GitHubConsumer.Models
 {
+    public class GitHubActionsWorkflowResponse
+    {
+        public int total_count { get; set; }
+        public List<GitHubActionsWorkflow> workflows { get; set; }
+    }
+
     public class GitHubActionsWorkflow
     {
         public int Id { get; set; }

--- a/GitHubConsumer/Utilities/GitHubRestClient.cs
+++ b/GitHubConsumer/Utilities/GitHubRestClient.cs
@@ -8,6 +8,7 @@ namespace GitHubConsumer.Utilities
     public class GitHubRestClient
     {
         private HttpClient _httpClient;
+        private const string API_BASE = "https://api.github.com";
 
         /// <summary>
         /// Creates a new HttpClient with the required headers for GitHub API calls
@@ -24,6 +25,12 @@ namespace GitHubConsumer.Utilities
             _httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Token", authToken);
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="owner"></param>
+        /// <param name="authToken"></param>
+        /// <returns></returns>
         public static IEnumerable<GitHubRepo> GetRepos(string owner, string authToken)
         {
             var ghr = new GitHubRestClient(authToken);
@@ -31,7 +38,7 @@ namespace GitHubConsumer.Utilities
             IEnumerable<GitHubRepo> data = new List<GitHubRepo>();
 
             // string URL = "https://api.github.com/users/" + owner + "/repos";
-            var response = ghr._httpClient.GetAsync($"https://api.github.com/users/{owner}/repos").Result;
+            var response = ghr._httpClient.GetAsync($"{API_BASE}/users/{owner}/repos").Result;
             if (response.IsSuccessStatusCode)
             {
                 data = response.Content.ReadFromJsonAsync<IEnumerable<GitHubRepo>>().Result;
@@ -41,16 +48,33 @@ namespace GitHubConsumer.Utilities
                 Console.WriteLine("{0} ({1})", (int)response.StatusCode, response.ReasonPhrase);
             }
 
-            return data.ToList();
+            return data;
         }
 
-        public async Task<GitHubActionsWorkflow> GetWorkflowAsync(string owner, string repo, string workflowId)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="owner"></param>
+        /// <param name="repo"></param>
+        /// <param name="authToken"></param>
+        /// <returns></returns>
+        public static GitHubActionsWorkflowResponse GetRepoWorkflows(string owner, string repo, string authToken)
         {
-            var response = await _httpClient.GetAsync($"repos/{owner}/{repo}/actions/workflows/{workflowId}");
-            response.EnsureSuccessStatusCode();
+            var ghr = new GitHubRestClient(authToken);
+            GitHubActionsWorkflowResponse data = new GitHubActionsWorkflowResponse();
 
-            using var responseStream = await response.Content.ReadAsStreamAsync();
-            return await JsonSerializer.DeserializeAsync<GitHubActionsWorkflow>(responseStream);
+            var response = ghr._httpClient.GetAsync($"{API_BASE}/repos/{owner}/{repo}/actions/workflows").Result;
+            if (response.IsSuccessStatusCode)
+            {
+                data = response.Content.ReadFromJsonAsync<GitHubActionsWorkflowResponse>().Result;
+            }
+            else
+            {
+                // Print the unsuccessful response code.
+                Console.WriteLine("{0} ({1})", (int)response.StatusCode, response.ReasonPhrase);
+            }
+
+            return data;
         }
     }
 }

--- a/GitHubConsumer/Utilities/GitHubRestClient.cs
+++ b/GitHubConsumer/Utilities/GitHubRestClient.cs
@@ -1,0 +1,56 @@
+﻿using GitHubConsumer.Models;
+using Microsoft.Extensions.Configuration;
+using System.Net.Http.Headers;
+using System.Text.Json;
+
+namespace GitHubConsumer.Utilities
+{
+    public class GitHubRestClient
+    {
+        private HttpClient _httpClient;
+
+        /// <summary>
+        /// Creates a new HttpClient with the required headers for GitHub API calls
+        /// </summary>
+        /// <param name="authToken"></param>
+        private GitHubRestClient(string authToken)
+        {
+            _httpClient = new HttpClient();
+            _httpClient.DefaultRequestHeaders.Accept.Add(
+                new MediaTypeWithQualityHeaderValue("application/vnd.github.v3+json")
+            );
+            _httpClient.DefaultRequestHeaders.UserAgent.Add(new System.Net.Http.Headers.ProductInfoHeaderValue("GitHubConsumerApp", "1.0"));
+            _httpClient.DefaultRequestHeaders.Add("X-GitHub-Api-Version", "2022-11-28");
+            _httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Token", authToken);
+        }
+
+        public static IEnumerable<GitHubRepo> GetRepos(string owner, string authToken)
+        {
+            var ghr = new GitHubRestClient(authToken);
+
+            IEnumerable<GitHubRepo> data = new List<GitHubRepo>();
+
+            // string URL = "https://api.github.com/users/" + owner + "/repos";
+            var response = ghr._httpClient.GetAsync($"https://api.github.com/users/{owner}/repos").Result;
+            if (response.IsSuccessStatusCode)
+            {
+                data = response.Content.ReadFromJsonAsync<IEnumerable<GitHubRepo>>().Result;
+            } else
+            {
+                // Print the unsuccessful response code.
+                Console.WriteLine("{0} ({1})", (int)response.StatusCode, response.ReasonPhrase);
+            }
+
+            return data.ToList();
+        }
+
+        public async Task<GitHubActionsWorkflow> GetWorkflowAsync(string owner, string repo, string workflowId)
+        {
+            var response = await _httpClient.GetAsync($"repos/{owner}/{repo}/actions/workflows/{workflowId}");
+            response.EnsureSuccessStatusCode();
+
+            using var responseStream = await response.Content.ReadAsStreamAsync();
+            return await JsonSerializer.DeserializeAsync<GitHubActionsWorkflow>(responseStream);
+        }
+    }
+}


### PR DESCRIPTION
API now supports pulling workflow information for a specific repo. Additionally, moved HttpClient logic to a separate class (`GitHubRestClient`) that manages calling the GitHub REST API. This separates logic away from the controller keeping things more manageable.

![image](https://github.com/meddlin/github-consumer/assets/8764066/deb93957-a94b-4d17-9863-7e1542dc7ef4)
